### PR TITLE
Fix home row mod timing to prevent false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,15 @@ Disabled layer (all keys inactive)
 - **JKL**: Toggle between Empty and Games layers
 
 ### Custom Behaviors
-- **Hold-Tap**: Balanced hold-tap with 200ms tapping term
-- **Quick-Tap**: 150ms quick-tap for rapid repeated taps
-- **Prior-Idle**: 120ms requirement to prevent accidental holds
+- **Hold-Tap (Standard)**: Balanced hold-tap with 280ms tapping term for most modifiers
+- **Hold-Tap (Strict)**: Tap-preferred hold-tap with 300ms tapping term for shift keys to reduce false positives
+- **Quick-Tap**: 175ms quick-tap for rapid repeated taps
+- **Prior-Idle**: 150-200ms requirement to prevent accidental holds during fast typing
+
+#### Home Row Mod Timing
+The configuration uses two different hold-tap behaviors to optimize typing experience:
+- **Standard timing** for Ctrl, Alt, GUI modifiers (280ms tapping term)
+- **Strict timing** for Shift modifiers (300ms, tap-preferred) to prevent accidental "fi" instead of "I" issues
 
 ## Configuration Files
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -25,9 +25,9 @@
 #define LGUI_A        &ht LGUI   A
 #define LALT_S        &ht LALT   S
 #define LCTL_D        &ht LCTRL  D
-#define LSHIFT_F      &ht LSHIFT F
+#define LSHIFT_F      &ht_strict LSHIFT F  // Using stricter timing for shift
 
-#define RSHIFT_J      &ht RSHIFT J
+#define RSHIFT_J      &ht_strict RSHIFT J  // Using stricter timing for shift
 #define RCTL_K        &ht RCTRL  K
 #define RALT_L        &ht RALT   L
 #define RGUI_SEMI     &ht RGUI   SEMI
@@ -35,9 +35,9 @@
 // for colemak layout
 #define LALT_R        &ht LALT   R
 #define LCTL_S        &ht LCTRL  S
-#define LSHIFT_T      &ht LSHIFT T
+#define LSHIFT_T      &ht_strict LSHIFT T  // Using stricter timing for shift
 
-#define RSHIFT_N      &ht RSHIFT N
+#define RSHIFT_N      &ht_strict RSHIFT N  // Using stricter timing for shift
 #define RCTL_E        &ht RCTRL  E
 #define RALT_I        &ht RALT   I
 #define RGUI_O        &ht RGUI   O

--- a/config/include/behaviors.dtsi
+++ b/config/include/behaviors.dtsi
@@ -1,5 +1,5 @@
-#define TAPPING_TERM 200
-#define QUICK_TAP_TERM 150
+#define TAPPING_TERM 280
+#define QUICK_TAP_TERM 175
 
 
 ht: hold_tap {
@@ -9,7 +9,20 @@ ht: hold_tap {
     flavor = "balanced";
     tapping-term-ms = <TAPPING_TERM>;
     quick-tap-ms = <QUICK_TAP_TERM>;
-    require-prior-idle-ms = <120>;
+    require-prior-idle-ms = <150>;
+    global-quick-tap;
+    bindings = <&kp>, <&kp>;
+};
+
+// Alternative home row mod with stricter timing
+ht_strict: hold_tap_strict {
+    label = "hold_tap_strict";
+    compatible = "zmk,behavior-hold-tap";
+    #binding-cells = <2>;
+    flavor = "tap-preferred";
+    tapping-term-ms = <300>;
+    quick-tap-ms = <200>;
+    require-prior-idle-ms = <200>;
     global-quick-tap;
     bindings = <&kp>, <&kp>;
 };


### PR DESCRIPTION
## Problem
Users experiencing issues where home row mods produce unintended character combinations (e.g., 'fi' instead of 'I' when using Shift+F with I).

## Solution
This PR improves home row modifier timing to reduce false positives:

### Changes Made
- **Increased standard tapping term**: 200ms → 280ms for better hold detection
- **Added strict hold-tap behavior**: New `ht_strict` behavior for problematic keys
- **Shift-specific tuning**: Applied strict timing (300ms, tap-preferred) to shift keys
- **Updated prior-idle timing**: 120ms → 150-200ms to prevent accidental holds
- **Documentation**: Updated README with detailed behavior explanations

### Technical Details
- `LSHIFT_F`, `RSHIFT_J`, `LSHIFT_T`, `RSHIFT_N` now use `ht_strict`
- Strict behavior uses `tap-preferred` flavor to prioritize taps over holds
- Longer timing windows give more time for proper hold detection
- Different timing for different modifier types optimizes typing experience

### Benefits
- Significantly reduces 'false positive' modifier activations
- Maintains responsive typing feel for non-problematic keys
- Provides better distinction between intentional holds and fast typing
- Documented configuration makes it easier for others with similar issues

## Testing
Please test this configuration and report if you still experience issues with:
- Shift combinations producing unwanted characters
- Other home row mod false positives
- Any reduction in typing responsiveness

Closes #[issue-number-if-exists]